### PR TITLE
Resolved .stibnite-ignore nested path problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,10 +131,5 @@ dmypy.json
 # pycharm
 .idea/
 
-# custom
-stibnite/dev.py
-
-example/
-
 # vscode
 .vscode/

--- a/example/src/class_and_function.py
+++ b/example/src/class_and_function.py
@@ -75,7 +75,6 @@ class Shark:
             print("lololo")
         return
 
-
     def be_awesome(self):
         """
         Take the max between two numbers

--- a/example/src/fullsupport_docstring.py
+++ b/example/src/fullsupport_docstring.py
@@ -57,7 +57,7 @@ def fullsupport(x: float, y: float = 3):
 
     and code inline with syntax highlights: `#!py3 import numpy as np`
 
-    Link to other sites (http://www.google.com) or other part of the doc [function test](zoomext.md#test)
+    Link to other sites (http://www.google.com)
 
     ??? note "note block with display"
         You can also add note on a block that can be hidden
@@ -69,7 +69,6 @@ def fullsupport(x: float, y: float = 3):
 
     """
     return np.max(x, y)
-
 
 
 def test(x: int):

--- a/example/src/functions.py
+++ b/example/src/functions.py
@@ -18,7 +18,6 @@ def mini(x, y):
     return np.min(x, y)
 
 
-
 def mini2peutetre(x, y):
     """
     Take the max between two numbers

--- a/example/src/subfolder/functions.py
+++ b/example/src/subfolder/functions.py
@@ -18,7 +18,6 @@ def mini(x, y):
     return np.min(x, y)
 
 
-
 def mini2peutetre(x, y):
     """
     Take the max between two numbers

--- a/example/src/subfolder2/subfolder3/ignore_test.py
+++ b/example/src/subfolder2/subfolder3/ignore_test.py
@@ -1,0 +1,2 @@
+def ignore_test():
+    print("Hi folks, I'm ignore_test function.")

--- a/example/src/xyz_build.py
+++ b/example/src/xyz_build.py
@@ -1,0 +1,2 @@
+def build_function():
+    print("Hi folks, I'm build function")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs-material==7.0.5
-pathspec==0.8.1
+igittigitt==2.0.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/csci-arch/stibnite",
     packages=setuptools.find_packages(),
     entry_points={"console_scripts": ["stibnite=stibnite.main:main"]},
-    install_requires=['mkdocs', 'mkdocs-material', 'pymdown-extensions', 'pathspec'],
+    install_requires=["mkdocs-material", "igittigitt"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/stibnite/constants.py
+++ b/stibnite/constants.py
@@ -1,9 +1,3 @@
-WINDOWS = "Windows"
-LINUX = "Linux"
-
-SEPARATOR_DICT = {WINDOWS: "\\",
-                  LINUX: "/"}
-
 NAME = "name"
 EXPLANATION = "explanation"
 TYPE = "type"

--- a/stibnite/dev.py
+++ b/stibnite/dev.py
@@ -2,7 +2,6 @@ from stibnite.documentation_manager import DocumentationManager
 from stibnite import constants
 from subprocess import call
 import webbrowser
-import platform
 import os
 
 if __name__ == "__main__":
@@ -10,7 +9,7 @@ if __name__ == "__main__":
     output_path = r""
 
     # Be careful about input output style :)
-    DocumentationManager(source_path, output_path, platform.system(),
+    DocumentationManager(source_path, output_path,
                          input_style=constants.RESTRUCTERED,
                          output_style=constants.MARKDOWN).write_file_structure()
 

--- a/stibnite/documentation_manager.py
+++ b/stibnite/documentation_manager.py
@@ -1,4 +1,4 @@
-from stibnite import file_operations, docstring_styler, constants
+from stibnite import file_operations, docstring_styler
 import os
 
 
@@ -9,29 +9,26 @@ class DocumentationManager:
     :type source_path: string
     :param output_path: The path of the folder that is going to contain outputs
     :type output_path: string
-    :param os_name: Name of the os that the user is using
-    :type os_name: string
     :param output_style: Name of the style that the documentation will be written in
     :type output_style: string
     :param input_style: Name of the style that the documentation is written in
     :type input_style: string
     """
-    def __init__(self, source_path, output_path, os_name, output_style, input_style):
-        self.package_name = os.path.abspath(source_path).split(constants.SEPARATOR_DICT[os_name])[-1]
+    def __init__(self, source_path, output_path, output_style, input_style):
+        self.package_name = os.path.abspath(source_path).split(os.sep)[-1]
         self.package_path = os.path.abspath(source_path)
-        self.documentation_name = os.path.abspath(output_path).split(constants.SEPARATOR_DICT[os_name])[-1]
+        self.documentation_name = os.path.abspath(output_path).split(os.sep)[-1]
         self.documentation_path = os.path.abspath(output_path)
-        self.os_name = os_name
         self.input_style = input_style
         self.output_style = output_style
         self.file_operator = file_operations.FileOperations(self.package_path,
                                                             self.documentation_path,
-                                                            self.documentation_name,
-                                                            self.os_name)
+                                                            self.documentation_name)
         self.file_structure = self.get_styled_structure(self.get_file_structure())
 
     def get_file_structure(self):
-        """Reads the source code and returns a file structure which is like a file tree that contains all the information about the source code.
+        """Reads the source code and returns a file structure which is like a file tree that contains all the
+        information about the source code.
 
         :return: The root of the file structure
         :rtype: stibnite.file_operations.FolderType
@@ -43,10 +40,12 @@ class DocumentationManager:
 
         :param file_structure: The root of a file structure
         :type file_structure: stibnite.file_operations.FolderType
-        :return: The same root but each documentation field in stibnite.file_operations.FileType under the file structure of the root is filled with stylized documentation text 
+        :return: The same root but each documentation field in stibnite.file_operations.FileType under the
+        file structure of the root is filled with stylized documentation text
         :rtype: stibnite.file_operations.FolderType
         """
-        return docstring_styler.DocstringStyler(self.output_style, self.input_style).get_styled_structure(file_structure)
+        return docstring_styler.DocstringStyler(self.output_style,
+                                                self.input_style).get_styled_structure(file_structure)
 
     def write_file_structure(self):
         """Writes the documentation and other necessary files for mkdocs.

--- a/stibnite/main.py
+++ b/stibnite/main.py
@@ -1,7 +1,6 @@
 from stibnite import DocumentationManager, constants
 from subprocess import call
 import webbrowser
-import platform
 import sys
 import os
 
@@ -11,7 +10,7 @@ def main(argv=None):
 
     print(argv)
 
-    DocumentationManager(argv[1], argv[2], platform.system(),
+    DocumentationManager(argv[1], argv[2],
                          input_style=constants.RESTRUCTERED,
                          output_style=constants.MARKDOWN).write_file_structure()
 

--- a/stibnite/utils.py
+++ b/stibnite/utils.py
@@ -1,4 +1,3 @@
-import platform
 import pathlib
 
 
@@ -25,6 +24,9 @@ def traverse_file_structure(current, function, **inner_function_args):
 
 
 def get_project_path():
-    from stibnite import constants
-    separator = constants.SEPARATOR_DICT[platform.system()]
-    return f"{pathlib.Path(__file__).parent.parent}{separator}"
+    """Returns stibnite project path
+
+    :return: project path
+    :rtype: string
+    """
+    return pathlib.Path(__file__).parent.parent

--- a/tests/test_docstring_styler.py
+++ b/tests/test_docstring_styler.py
@@ -1,7 +1,7 @@
-import pytest
-import platform
 import inspect
+import pytest
 import copy
+import os
 
 
 def test_docstringparser_parse_docstring():
@@ -216,7 +216,8 @@ def this_is_an_example_source_code(with_multiple_tabs, and, spaces):
         f'??? info "Source Code" \n\t```py3 linenums="1 1 2" \n\n', "")
 
     assert res_case1.split("\n")[0][0] == "\t"
-    assert res_case1.split("\n")[0].split("\t")[1] == "def this_is_an_example_source_code(with_multiple_tabs, and, spaces):"
+    assert res_case1.split("\n")[0].split("\t")[1] == \
+           "def this_is_an_example_source_code(with_multiple_tabs, and, spaces):"
 
     assert res_case2.split("\n")[0][0] == "\t"
     assert res_case2.split("\n")[0].split("\t")[1] == "def inner_tab():"
@@ -302,12 +303,18 @@ def test_docstringstyler__style_docstring_md():
     expected_case2 = "Example one line below\n\n"
     expected_case3 = "Example without param\n\n"
     expected_case4 = "Example with param\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n"
-    expected_case5 = "Example without param type test\n\n**Parameters**\n\n> **x:** `n/a` -- example text for param x\n\n"
-    expected_case6 = "Example with param without empty line\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n"
-    expected_case7 = "Example with return\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n**Returns**\n\n> `n/a` -- description of return\n\n"
-    expected_case8 = "Example with return and return type\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n**Returns**\n\n> `some return type` -- description of return\n\n"
-    expected_case9 = "Example with multi text param\n\n**Parameters**\n\n> **x:** `sometype` -- example multi text for param x\n\n"
-    expected_case10 = "Example with return type but without return desc\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n**Returns**\n\n> `somethingweird`\n\n"
+    expected_case5 = "Example without param type test\n\n**Parameters**\n\n> **x:** `n/a` -- example text for param " \
+                     "x\n\n"
+    expected_case6 = "Example with param without empty line\n\n**Parameters**\n\n> **x:** `sometype` -- example text" \
+                     " for param x\n\n"
+    expected_case7 = "Example with return\n\n**Parameters**\n\n> **x:** `sometype` -- example text for param x\n\n" \
+                     "**Returns**\n\n> `n/a` -- description of return\n\n"
+    expected_case8 = "Example with return and return type\n\n**Parameters**\n\n> **x:** `sometype` -- example text " \
+                     "for param x\n\n**Returns**\n\n> `some return type` -- description of return\n\n"
+    expected_case9 = "Example with multi text param\n\n**Parameters**\n\n> **x:** `sometype` -- example multi text " \
+                     "for param x\n\n"
+    expected_case10 = "Example with return type but without return desc\n\n**Parameters**\n\n> **x:** `sometype` -- " \
+                      "example text for param x\n\n**Returns**\n\n> `somethingweird`\n\n"
 
     res_case1 = DocstringStyler._style_docstring_md(case1, constants.RESTRUCTERED)
     res_case2 = DocstringStyler._style_docstring_md(case2, constants.RESTRUCTERED)
@@ -350,9 +357,9 @@ def test_docstringstyler__style_class_md():
     from stibnite.utils import get_project_path
     from stibnite.file_operations import import_module
     from stibnite.docstring_styler import DocstringStyler
-    separator = constants.SEPARATOR_DICT[platform.system()]
 
-    module = import_module("src.class_and_function", f"{get_project_path()}example{separator}src{separator}class_and_function.py")
+    module = import_module("src.class_and_function",
+                           os.path.join(get_project_path(), "example", "src", "class_and_function.py"))
 
     shark_class = [
         ClassType(obj)
@@ -368,15 +375,14 @@ def test_docstringstyler__style_class_md():
 
 
 def test_docstringstyler__style_func_md():
-    from stibnite.core_types import FunctionType,ClassType
+    from stibnite.core_types import FunctionType, ClassType
     from stibnite import constants
     from stibnite.utils import get_project_path
     from stibnite.file_operations import import_module
     from stibnite.docstring_styler import DocstringStyler
-    separator = constants.SEPARATOR_DICT[platform.system()]
 
     module = import_module("src.class_and_function",
-                           f"{get_project_path()}example{separator}src{separator}class_and_function.py")
+                           os.path.join(get_project_path(), "example", "src", "class_and_function.py"))
 
     shark_class = [
         ClassType(obj)
@@ -403,7 +409,8 @@ def test_docstringstyler__style_func_md():
     result = DocstringStyler._style_func_md(copy.deepcopy(swimclass_method), constants.MARKDOWN, ismethod=True)
 
     assert isinstance(result, FunctionType)
-    assert result.name == DocstringStyler._style_method_name_md(swimclass_method.obj.__self__.__class__.__name__, swimclass_method.name, swimclass_method.args)
+    assert result.name == DocstringStyler._style_method_name_md(swimclass_method.obj.__self__.__class__.__name__,
+                                                                swimclass_method.name, swimclass_method.args)
     assert result.name_in_list == DocstringStyler._style_function_name_in_list_md(swimclass_method.name_in_list)
     assert result.doc == DocstringStyler._style_docstring_md(swimclass_method.doc, constants.MARKDOWN)
     assert result.source == DocstringStyler._style_source_code_md(swimclass_method.source)
@@ -415,10 +422,9 @@ def test_docstringstyler__style_file_md():
     from stibnite.utils import get_project_path
     from stibnite.file_operations import import_module, FileType
     from stibnite.docstring_styler import DocstringStyler
-    separator = constants.SEPARATOR_DICT[platform.system()]
 
     module = import_module("src.class_and_function",
-                           f"{get_project_path()}example{separator}src{separator}class_and_function.py")
+                           os.path.join(get_project_path(), "example", "src", "class_and_function.py"))
 
     classes = [
         ClassType(obj)
@@ -442,16 +448,16 @@ def test_docstringstyler__style_file_md():
     assert isinstance(result.documentation, dict)
     assert isinstance(result.documentation[constants.CONTENT], str)
 
+
 def test_docstringstyler_get_styled_structure():
     from stibnite.core_types import FunctionType, ClassType
     from stibnite import constants
     from stibnite.utils import get_project_path
     from stibnite.file_operations import import_module, FileType, FolderType
     from stibnite.docstring_styler import DocstringStyler
-    separator = constants.SEPARATOR_DICT[platform.system()]
 
     module = import_module("src.class_and_function",
-                           f"{get_project_path()}example{separator}src{separator}class_and_function.py")
+                           os.path.join(get_project_path(), "example", "src", "class_and_function.py"))
 
     classes = [
         ClassType(obj)
@@ -479,4 +485,3 @@ def test_docstringstyler_get_styled_structure():
 
 if __name__ == "__main__":
     pytest.main()
-


### PR DESCRIPTION
- Library used for parsing .stibnite-ignore file changed to igittigitt
- Added nested files and anchored file cases to examples
- Removed separator_dictionary structure
- All path operations are done with the os.path. (It provides working os independent)